### PR TITLE
Fix error on Akismet admin screen

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -19,9 +19,9 @@ after_initialize do
   if SiteSetting.signatures_enabled then
     add_to_serializer(:post, :user_signature, false) {
       if SiteSetting.signatures_advanced_mode then
-        object.user.custom_fields['signature_raw']
+        object.user.custom_fields['signature_raw'] if object.user
       else
-        object.user.custom_fields['signature_url']
+        object.user.custom_fields['signature_url'] if object.user
       end
     }
 


### PR DESCRIPTION
Error was:

Started GET "/admin/plugins/akismet/index.json?_=1489512223986" for 77.163.254.28 at 2017-03-14 17:23:59 +0000
Processing by DiscourseAkismet::AdminModQueueController#index as JSON
  Parameters: {"_"=>"1489512223986"}
Completed 500 Internal Server Error in 29ms (ActiveRecord: 17.5ms)
 NoMethodError (undefined method `custom_fields' for nil:NilClass)
/var/www/discourse/plugins/discourse-signatures/plugin.rb:22:in `block (2 levels) in activate!'

