### PR TITLE
Adding Minimum User Trust Level Requirement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,10 @@
     "browser": true,
     "builtin": true
   },
-  ecmaVersion: 7,
+  "parserOptions": {
+    "ecmaVersion": 7,
+    "sourceType": "module"
+  },
   "globals":
     {"Ember":true,
     "jQuery":true,

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/*
 *.iml
+
+.rubocop-https---raw-githubusercontent-com-discourse-discourse-master--rubocop-yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: https://raw.githubusercontent.com/discourse/discourse/master/.rubocop.yml

--- a/assets/javascripts/discourse/initializers/extend-for-signatures.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-signatures.js.es6
@@ -20,9 +20,7 @@ function attachSignature(api, siteSettings) {
             dec.h(
               "div",
               new RawHtml({
-                html: `<div class='user-signature'>${
-                  attrs.user_signature
-                }</div>`
+                html: `<div class='user-signature'>${attrs.user_signature}</div>`
               })
             )
           ];

--- a/assets/javascripts/discourse/initializers/extend-for-signatures.js.es6
+++ b/assets/javascripts/discourse/initializers/extend-for-signatures.js.es6
@@ -1,22 +1,38 @@
-import { withPluginApi } from 'discourse/lib/plugin-api';
-import RawHtml from 'discourse/widgets/raw-html';
+import { withPluginApi } from "discourse/lib/plugin-api";
+import RawHtml from "discourse/widgets/raw-html";
 
 function attachSignature(api, siteSettings) {
-  api.includePostAttributes('user_signature');
+  api.includePostAttributes("user_signature");
 
-  api.decorateWidget('post-contents:after-cooked', dec => {
-
+  api.decorateWidget("post-contents:after-cooked", dec => {
     const attrs = dec.attrs;
-    if (Ember.isEmpty(attrs.user_signature)) { return; }
+    if (Ember.isEmpty(attrs.user_signature)) {
+      return;
+    }
 
     const currentUser = api.getCurrentUser();
     if (currentUser) {
-      const enabled = currentUser.get('custom_fields.see_signatures');
+      const enabled = currentUser.get("custom_fields.see_signatures");
       if (enabled) {
         if (siteSettings.signatures_advanced_mode) {
-          return [dec.h('hr'), dec.h('div', new RawHtml({html: `<div class='user-signature'>${attrs.user_signature}</div>`}))];
+          return [
+            dec.h("hr"),
+            dec.h(
+              "div",
+              new RawHtml({
+                html: `<div class='user-signature'>${
+                  attrs.user_signature
+                }</div>`
+              })
+            )
+          ];
         } else {
-          return [dec.h('hr'), dec.h('img.signature-img', {attributes: {src: attrs.user_signature}})];
+          return [
+            dec.h("hr"),
+            dec.h("img.signature-img", {
+              attributes: { src: attrs.user_signature }
+            })
+          ];
         }
       }
     }
@@ -24,11 +40,11 @@ function attachSignature(api, siteSettings) {
 }
 
 export default {
-  name: 'extend-for-signatures',
+  name: "extend-for-signatures",
   initialize(container) {
-    const siteSettings = container.lookup('site-settings:main');
+    const siteSettings = container.lookup("site-settings:main");
     if (siteSettings.signatures_enabled) {
-      withPluginApi('0.1', api => attachSignature(api, siteSettings));
+      withPluginApi("0.1", api => attachSignature(api, siteSettings));
     }
   }
 };

--- a/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-custom-preferences/signature-preferences.hbs
@@ -1,7 +1,7 @@
 {{#if siteSettings.signatures_enabled}}
   <div class="control-group signatures">
     <label class="control-label">Enable Signatures</label>
-    <div class="controls">
+    <div class="controls bio-composer input-xxlarge">
       <label class='checkbox-label'>
         {{input type="checkbox" checked=model.custom_fields.see_signatures}}
           See user signatures below posts

--- a/plugin.rb
+++ b/plugin.rb
@@ -37,7 +37,7 @@ after_initialize do
 
   # This is the code responsible for cooking a new advanced mode sig on user update
   DiscourseEvent.on(:user_updated) do |user|
-    if SiteSetting.signatures_enabled? && SiteSetting.signatures_advanced_mode
+    if SiteSetting.signatures_enabled? && SiteSetting.signatures_advanced_mode && user.custom_fields['signature_raw']
       cooked_sig = PrettyText.cook(user.custom_fields['signature_raw'], omit_nofollow: user.has_trust_level?(TrustLevel[3]) && !SiteSetting.tl3_links_no_follow)
       # avoid infinite recurrsion
       if cooked_sig != user.custom_fields['signature_cooked']

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # name: discourse-signatures
 # about: A plugin to get that nostalgia signatures in Discourse Foruns
 # version: 2.0.0

--- a/plugin.rb
+++ b/plugin.rb
@@ -39,8 +39,11 @@ after_initialize do
   DiscourseEvent.on(:user_updated) do |user|
     if SiteSetting.signatures_enabled? && SiteSetting.signatures_advanced_mode
       cooked_sig = PrettyText.cook(user.custom_fields['signature_raw'], omit_nofollow: user.has_trust_level?(TrustLevel[3]) && !SiteSetting.tl3_links_no_follow)
-      user.custom_fields['signature_cooked'] = cooked_sig
-      user.save
+      # avoid infinite recurrsion
+      if cooked_sig != user.custom_fields['signature_cooked']
+        user.custom_fields['signature_cooked'] = cooked_sig
+        user.save
+      end
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -39,7 +39,7 @@ after_initialize do
   DiscourseEvent.on(:user_updated) do |user|
     if SiteSetting.signatures_enabled? && SiteSetting.signatures_advanced_mode && user.custom_fields['signature_raw']
       cooked_sig = PrettyText.cook(user.custom_fields['signature_raw'], omit_nofollow: user.has_trust_level?(TrustLevel[3]) && !SiteSetting.tl3_links_no_follow)
-      # avoid infinite recurrsion
+      # avoid infinite recursion
       if cooked_sig != user.custom_fields['signature_cooked']
         user.custom_fields['signature_cooked'] = cooked_sig
         user.save

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 # about: A plugin to get that nostalgia signatures in Discourse Foruns
 # version: 2.0.0
 # author: Rafael Silva <xfalcox@gmail.com>
-# url: https://github.com/xfalcox/discourse-signatures
+# url: https://github.com/discourse/discourse-signatures
 
 enabled_site_setting :signatures_enabled
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,6 +16,8 @@ after_initialize do
   User.register_custom_field_type('signature_url', :text)
   User.register_custom_field_type('signature_raw', :text)
 
+  register_editable_user_custom_field [:see_signatures, :signature_url, :signature_raw]
+
   if SiteSetting.signatures_enabled then
     add_to_serializer(:post, :user_signature, false) {
       if SiteSetting.signatures_advanced_mode then


### PR DESCRIPTION
It will be useful to prevent new users from being able to use this feature. Limiting it to a specific User Trust Level will reduce spam. Users has to work their way out in order to earn the signatures. 